### PR TITLE
VSSL-5245 Fix no longer released TF1 Image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,27 +56,6 @@ executors:
       - image: cimg/base:stable
 
 jobs:
-  push-tf1-ngc-prev:
-    executor: kernel-imnge-publising-docker
-    steps:
-      - checkout
-      - run:
-          name: store variables
-          command: |
-            echo "export DATE=$(date +'%Y%m%d%H%M')" >> "$BASH_ENV"
-            echo "export NGC_TAG_VERSION=$(date -d '-1 months' '+%y.%m')" >> "$BASH_ENV"
-            source "$BASH_ENV"
-      - push-docker-image:
-          filename: "py3-tf-ngc"
-          tag: $NGC_TAG_VERSION-tf1-py3
-          repo: "ngc-tensorflow-kernel"
-      - insert-image-database
-      - slack/status:
-          include_project_field: false
-          include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n
-          <https://docs.nvidia.com/deeplearning/frameworks/`echo $IMAGE_TAG_NAME | cut -d "/" -f 3 | cut -d "-" -f2`-release-notes/rel-`echo $NGC_TAG_VERSION | cut -d "." -f 1`-`echo $NGC_TAG_VERSION | cut -d "." -f 2`.html|*See NGC Release Notes*>'
   push-tf2-ngc-prev:
     executor: kernel-imnge-publising-docker
     steps:
@@ -203,15 +182,6 @@ jobs:
 workflows: 
   main:
     jobs:
-      - push-tf1-ngc-prev:
-          context:
-            - quay-creds
-            - kernel-image-publish-secrets
-            - slack-webhook-for-v3-orb
-          filters:
-            branches:
-              only:
-                - main
       - push-tf2-ngc-prev:
           context:
             - quay-creds


### PR DESCRIPTION
NGC 기반으로 생성되고 있는 Tensorflow 1은 NGC에서 공식적으로 더 이상 지원하지 않습니다.
따라서 저희도 TF1 Kernel Image는 더 이상 배포하지 않을 예정입니다.

+) BE 상에 있는 KernelImagePublishNewManagedImageAPI도 확인해본 결과 별도의 수정을 안해도 되어 일단 circleci만 수정합니다.