### PR TITLE
[VSSL-7362] Updated NGC Image Tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,9 @@ commands:
       - setup_remote_docker:
             version: 20.10.17
             docker_layer_caching: true
-      - run:
-          name: docker login
-          command: docker login -u $QUAY_ACCOUNT_USERNAME -p $QUAY_ACCOUNT_PASSWORD quay.io
+#      - run:
+#          name: docker login
+#          command: docker login -u $QUAY_ACCOUNT_USERNAME -p $QUAY_ACCOUNT_PASSWORD quay.io
       - run:
           name: store image tag
           command: |
@@ -42,12 +42,33 @@ commands:
       - run:
           name: docker build
           command: |
-            cd ./<<parameters.path>> &&  docker build --build-arg NGC_TAG=<<parameters.tag>> -f Dockerfile.<<parameters.filename>> -t $IMAGE_TAG_NAME .
+            cd ./<<parameters.path>> &&  sudo docker build --build-arg NGC_TAG=<<parameters.tag>> -f Dockerfile.<<parameters.filename>> -t $IMAGE_TAG_NAME .
       - run:
-          name: docker push
+          name: fetch python version
           command: |
-            docker push $IMAGE_TAG_NAME
-          no_output_timeout: 1h
+            export PY_VER=$(sudo docker run --rm $IMAGE_TAG_NAME /bin/bash -c 'python3 -V' | grep -o 'Python [0-9.]*' | awk '{print $2}')
+            echo "export PY_VER" >> "$BASH_ENV"
+            source "$BASH_ENV"
+            echo $PY_VER
+      - run:
+          name: fetch tensorflow version
+          command : |
+            export TF_VER=$(sudo docker run --rm $IMAGE_TAG_NAME /bin/bash -c 'pip show tensorflow' | grep -o 'Version: [0-9.]*' | awk '{print $2}')
+            echo "export TF_VER" >> "$BASH_ENV"
+            source "$BASH_ENV"
+            echo $TF_VER
+      - run:
+          name: fetch cuda version
+          command: |
+            export CUDA_VER=$(sudo docker run --rm $IMAGE_TAG_NAME /bin/bash -c 'nvcc -V' | grep -o 'release [0-9.]*' | awk '{print $2}')
+            echo "export CUDA_VER" >> "$BASH_ENV"
+            source "$BASH_ENV"
+            echo $CUDA_VER
+#      - run:
+#          name: docker push
+#          command: |
+#            docker push $IMAGE_TAG_NAME
+#          no_output_timeout: 1h
 
 executors:
   kernel-image-publishing-docker:
@@ -69,14 +90,15 @@ jobs:
       - push-docker-image:
           filename: "py3-tf-ngc"
           tag: "$NGC_TAG_VERSION-tf2-py3"
-          repo: "ngc-tensorflow-kernel"
-      - insert-image-database
-      - slack/status:
-          include_project_field: false
-          include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n
-          <https://docs.nvidia.com/deeplearning/frameworks/`echo $IMAGE_TAG_NAME | cut -d "/" -f 3 | cut -d "-" -f2`-release-notes/rel-`echo $NGC_TAG_VERSION | cut -d "." -f 1`-`echo $NGC_TAG_VERSION | cut -d "." -f 2`.html|*See NGC Release Notes*>'
+          repo: "tensorflow"
+#      - insert-image-database
+#      - slack/status:
+#          include_project_field: false
+#          include_job_number_field: false
+#          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
+#          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n
+#          <https://docs.nvidia.com/deeplearning/frameworks/`echo $IMAGE_TAG_NAME | cut -d "/" -f 3 | cut -d "-" -f2`-release-notes/rel-`echo $NGC_TAG_VERSION | cut -d "." -f 1`-`echo $NGC_TAG_VERSION | cut -d "." -f 2`.html|*See NGC Release Notes*>'
+
   push-pytorch-ngc-prev:
     executor: kernel-image-publishing-docker
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,9 +145,9 @@ commands:
       - setup_remote_docker:
             version: 20.10.17
             docker_layer_caching: true
-#      - run:
-#          name: docker login
-#          command: docker login -u $QUAY_ACCOUNT_USERNAME -p $QUAY_ACCOUNT_PASSWORD quay.io
+      - run:
+          name: docker login
+          command: docker login -u $QUAY_ACCOUNT_USERNAME -p $QUAY_ACCOUNT_PASSWORD quay.io
       - run:
           name: store image tag
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ commands:
       - run:
           name: docker build
           command: |
-            cd ./<<parameters.path>> &&  sudo docker build --platform=linux/amd64 --build-arg NGC_TAG=<<parameters.tag>> -f Dockerfile.<<parameters.filename>> -t $IMAGE_TAG_NAME .
+            cd ./<<parameters.path>> &&  docker build --platform=linux/amd64 --build-arg NGC_TAG=<<parameters.tag>> -f Dockerfile.<<parameters.filename>> -t $IMAGE_TAG_NAME .
 
 executors:
   kernel-image-publishing-docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ commands:
             curl -v -f -X POST https://api.vessl.ai/api/v1/kernels_images/publish_new_managed_image \
               -H "Authorization: $PROD_KERNEL_IMAGE_PUBLISH_SECRET_KEY" \
               -H "Content-type: application/json" \
-              -d "{\"image_url\": \"$IMAGE_TAG_NAME\"}"
+              -d "{\"image_url\": \"$NEW_TAG\"}"
   fetch-py-ver:
     steps:
       - run:
@@ -118,19 +118,16 @@ commands:
   push-docker-image:
     steps:
       - run:
-          name: docker push [MOCK]
+          name: docker push
           command: |
             echo "PUSHED $IMAGE_TAG_NAME AS $NEW_TAG"
-#            docker tag $IMAGE_TAG_NAME $NEW_TAG
-#            docker push $NEW_TAG
-#            WITHOUT_REV_VER=$(echo "$NEW_TAG" | sed 's/-r[0-9]*$//')
-#            docker tag $IMAGE_TAG_NAME $WITHOUT_REV_VER
-#            docker push $WITHOUT_REV_VER
-#      - run:
-#          name: docker push
-#          command: |
-#            docker push $IMAGE_TAG_NAME
-#            no_output_timeout: 1h
+            WITHOUT_REV_VER=$(echo "$NEW_TAG" | sed 's/-r[0-9]*$//')
+            docker tag $IMAGE_TAG_NAME $NEW_TAG
+            docker tag $IMAGE_TAG_NAME $WITHOUT_REV_VER
+            docker push $NEW_TAG
+            docker push $WITHOUT_REV_VER
+            no_output_timeout: 1h
+
   build-docker-image:
     parameters:
       filename:
@@ -185,13 +182,13 @@ jobs:
           repo: "tensorflow"
       - overwrite-tag-tf
       - push-docker-image
-#      - insert-image-database
-#      - slack/status:
-#          include_project_field: false
-#          include_job_number_field: false
-#          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
-#          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n
-#          <https://docs.nvidia.com/deeplearning/frameworks/`echo $IMAGE_TAG_NAME | cut -d "/" -f 3 | cut -d "-" -f2`-release-notes/rel-`echo $NGC_TAG_VERSION | cut -d "." -f 1`-`echo $NGC_TAG_VERSION | cut -d "." -f 2`.html|*See NGC Release Notes*>'
+      - insert-image-database
+      - slack/status:
+          include_project_field: false
+          include_job_number_field: false
+          failure_message: ':thinking_spin: \``echo ${NEW_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$NEW_TAG|\``echo ${NEW_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n
+          <https://docs.nvidia.com/deeplearning/frameworks/`echo $NEW_TAG | cut -d "/" -f 3 | cut -d "-" -f2`-release-notes/rel-`echo $NGC_TAG_VERSION | cut -d "." -f 1`-`echo $NGC_TAG_VERSION | cut -d "." -f 2`.html|*See NGC Release Notes*>'
 
   push-pytorch-ngc-prev:
     executor: kernel-image-publishing-docker
@@ -209,13 +206,14 @@ jobs:
           repo: "torch"
       - overwrite-tag-torch-cpu
       - push-docker-image
-#      - insert-image-database
-#      - slack/status:
-#          include_project_field: false
-#          include_job_number_field: false
-#          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
-#          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n
-#          <https://docs.nvidia.com/deeplearning/frameworks/`echo $IMAGE_TAG_NAME | cut -d "/" -f 3 | cut -d "-" -f2`-release-notes/rel-`echo $NGC_TAG_VERSION | cut -d "." -f 1`-`echo $NGC_TAG_VERSION | cut -d "." -f 2`.html|*See NGC Release Notes*>'
+      - insert-image-database
+      - slack/status:
+          include_project_field: false
+          include_job_number_field: false
+          failure_message: ':thinking_spin: \``echo ${NEW_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$NEW_TAG|\``echo ${NEW_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n
+          <https://docs.nvidia.com/deeplearning/frameworks/`echo $NEW_TAG | cut -d "/" -f 3 | cut -d "-" -f2`-release-notes/rel-`echo $NGC_TAG_VERSION | cut -d "." -f 1`-`echo $NGC_TAG_VERSION | cut -d "." -f 2`.html|*See NGC Release Notes*>'
+
   push-py38-cpu:
     executor: kernel-image-publishing-docker
     steps:
@@ -232,12 +230,13 @@ jobs:
           repo: "python"
       - overwrite-tag-python-cpu
       - push-docker-image
-#      - insert-image-database
-#      - slack/status:
-#          include_project_field: false
-#          include_job_number_field: false
-#          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
-#          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+      - insert-image-database
+      - slack/status:
+          include_project_field: false
+          include_job_number_field: false
+          failure_message: ':thinking_spin: \``echo ${NEW_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$NEW_TAG|\``echo ${NEW_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+
   push-py39-cpu:
     executor: kernel-image-publishing-docker
     steps:
@@ -254,12 +253,13 @@ jobs:
           repo: "python"
       - overwrite-tag-python-cpu
       - push-docker-image
-#      - insert-image-database
-#      - slack/status:
-#          include_project_field: false
-#          include_job_number_field: false
-#          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
-#          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+      - insert-image-database
+      - slack/status:
+          include_project_field: false
+          include_job_number_field: false
+          failure_message: ':thinking_spin: \``echo ${NEW_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$NEW_TAG|\``echo ${NEW_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+
   push-py310-cpu:
     executor: kernel-image-publishing-docker
     steps:
@@ -276,12 +276,13 @@ jobs:
           repo: "python"
       - overwrite-tag-python-cpu
       - push-docker-image
-#      - insert-image-database
-#      - slack/status:
-#          include_project_field: false
-#          include_job_number_field: false
-#          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
-#          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+      - insert-image-database
+      - slack/status:
+          include_project_field: false
+          include_job_number_field: false
+          failure_message: ':thinking_spin: \``echo ${NEW_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$NEW_TAG|\``echo ${NEW_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+
   push-py311-cpu:
     executor: kernel-image-publishing-docker
     steps:
@@ -298,12 +299,13 @@ jobs:
           repo: "python"
       - overwrite-tag-python-cpu
       - push-docker-image
-#      - insert-image-database
-#      - slack/status:
-#          include_project_field: false
-#          include_job_number_field: false
-#          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
-#          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+      - insert-image-database
+      - slack/status:
+          include_project_field: false
+          include_job_number_field: false
+          failure_message: ':thinking_spin: \``echo ${NEW_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$NEW_TAG|\``echo ${NEW_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+
   push-hub:
     executor: kernel-image-publishing-docker
     steps:
@@ -321,11 +323,11 @@ jobs:
       - overwrite-tag-torch-gpu
       - push-docker-image
       # - insert-image-database
-#      - slack/status:
-#          include_project_field: false
-#          include_job_number_field: false
-#          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
-#          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+      - slack/status:
+          include_project_field: false
+          include_job_number_field: false
+          failure_message: ':thinking_spin: \``echo ${NEW_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$NEW_TAG|\``echo ${NEW_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
 
 workflows: 
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,125 @@ commands:
               -H "Authorization: $PROD_KERNEL_IMAGE_PUBLISH_SECRET_KEY" \
               -H "Content-type: application/json" \
               -d "{\"image_url\": \"$IMAGE_TAG_NAME\"}"
+  fetch-py-ver:
+    steps:
+      - run:
+          name: fetch python version
+          command: |
+            PY_VER=$(sudo docker run --rm $IMAGE_TAG_NAME /bin/bash -c 'python3 -V' | grep -o 'Python [0-9.]*' | awk '{print $2}')
+            echo "export PY_VER=$PY_VER" >> "$BASH_ENV"
+            source "$BASH_ENV"
+            echo $PY_VER
+  fetch-tf-ver:
+    steps:
+      - run:
+          name: fetch tensorflow version
+          command: |
+            TF_VER=$(sudo docker run --rm $IMAGE_TAG_NAME /bin/bash -c 'pip show tensorflow' | grep -o 'Version: [0-9.]*' | awk '{print $2}')
+            echo "export TF_VER=$TF_VER" >> "$BASH_ENV"
+            source "$BASH_ENV"
+            echo $TF_VER
+  fetch-cuda-ver:
+    steps:
+      - run:
+          name: fetch cuda version
+          command: |
+            CUDA_VER=$(sudo docker run --rm $IMAGE_TAG_NAME /bin/bash -c 'nvcc -V' | grep -o 'release [0-9.]*' | awk '{print $2}')
+            echo "export CUDA_VER=$CUDA_VER" >> "$BASH_ENV"
+            source "$BASH_ENV"
+            echo $CUDA_VER
+  fetch-torch-ver:
+    steps:
+      - run:
+          name: fetch pytorch version
+          command: |
+            TORCH_VER=$(sudo docker run --rm $IMAGE_TAG_NAME /bin/bash | grep -o 'Version [0-9.]*' | awk '{print $2}')
+            echo "export TORCH_VER=$TORCH_VER" >> "$BASH_ENV"
+            source "$BASH_ENV"
+            echo $TORCH_VER
+  overwrite-tag-tf:
+    steps:
+      - fetch-tf-ver
+      - fetch-cuda-ver
+      - run:
+          name: overwrite tensorflow-gpu version info
+          command: |
+            VERSION_TAG=$TF_VER-cuda$CUDA_VER
+            echo "export VERSION_TAG=$VERSION_TAG" >> "$BASH_ENV"
+            source "$BASH_ENV"
+      - fetch-revision-ver:
+          repo: "tensorflow"
+  overwrite-tag-torch-cpu:
+    steps:
+      - fetch-torch-ver
+      - run:
+          name: overwrite torch-cpu version info
+          command: |
+            VERSION_TAG=$TORCH_VER-cpu
+            echo "export VERSION_TAG=$VERSION_TAG" >> "$BASH_ENV"
+            source "$BASH_ENV"
+      - fetch-revision-ver:
+          repo: "torch"
+  overwrite-tag-torch-gpu:
+    steps:
+      - fetch-torch-ver
+      - fetch-cuda-ver
+      - run:
+          name: overwrite torch-gpu version info
+          command: |
+            VERSION_TAG=$TORCH_VER-cuda$CUDA_VER
+            echo "export VERSION_TAG=$VERSION_TAG" >> "$BASH_ENV"
+            source "$BASH_ENV"
+      - fetch-revision-ver:
+          repo: "torch"
+  overwrite-tag-python-cpu:
+    steps:
+      - fetch-py-ver
+      - run:
+          name: overwrite python-cpu version info
+          command: |
+            VERSION_TAG=$PY_VER
+            echo "export VERSION_TAG=$VERSION_TAG" >> "$BASH_ENV"
+            source "$BASH_ENV"
+      - fetch-revision-ver:
+          repo: "python"
+  fetch-revision-ver:
+    parameters:
+      repo:
+        type: string
+    steps:
+      - run:
+          name: fetch revision version
+          command: |
+            suffix=1
+            while true; do
+              response_code=$(curl -s -o /dev/null -w "%{http_code}" "https://quay.io/v2/vessl-ai/<<parameters.repo>>/manifests/$VERSION_TAG-r$suffix")
+              if [[ $response_code != 200 ]]; then
+                break
+              fi
+              suffix=$((suffix + 1))
+            done
+            echo $suffix
+            NEW_TAG=$QUAY_ACCOUNT_URL/<<parameters.repo>>:$VERSION_TAG-r$suffix
+            echo "export NEW_TAG=$NEW_TAG" >> "$BASH_ENV"
+            source "$BASH_ENV"
   push-docker-image:
+    steps:
+      - run:
+          name: docker push [MOCK]
+          command: |
+            echo "PUSHED $IMAGE_TAG_NAME AS $NEW_TAG"
+#            docker tag $IMAGE_TAG_NAME $NEW_TAG
+#            docker push $NEW_TAG
+#            WITHOUT_REV_VER=$(echo "$NEW_TAG" | sed 's/-r[0-9]*$//')
+#            docker tag $IMAGE_TAG_NAME $WITHOUT_REV_VER
+#            docker push $WITHOUT_REV_VER
+#      - run:
+#          name: docker push
+#          command: |
+#            docker push $IMAGE_TAG_NAME
+#            no_output_timeout: 1h
+  build-docker-image:
     parameters:
       filename:
         type: string
@@ -36,39 +154,13 @@ commands:
       - run:
           name: store image tag
           command: |
-            export TAG="$QUAY_ACCOUNT_URL/<<parameters.repo>>:<<parameters.tag>>-$DATE"
+            export TAG="$QUAY_ACCOUNT_URL/<<parameters.repo>>:<<parameters.tag>>"
             echo "export IMAGE_TAG_NAME=$TAG" >> "$BASH_ENV"
             source "$BASH_ENV"
       - run:
           name: docker build
           command: |
-            cd ./<<parameters.path>> &&  sudo docker build --build-arg NGC_TAG=<<parameters.tag>> -f Dockerfile.<<parameters.filename>> -t $IMAGE_TAG_NAME .
-      - run:
-          name: fetch python version
-          command: |
-            export PY_VER=$(sudo docker run --rm $IMAGE_TAG_NAME /bin/bash -c 'python3 -V' | grep -o 'Python [0-9.]*' | awk '{print $2}')
-            echo "export PY_VER" >> "$BASH_ENV"
-            source "$BASH_ENV"
-            echo $PY_VER
-      - run:
-          name: fetch tensorflow version
-          command : |
-            export TF_VER=$(sudo docker run --rm $IMAGE_TAG_NAME /bin/bash -c 'pip show tensorflow' | grep -o 'Version: [0-9.]*' | awk '{print $2}')
-            echo "export TF_VER" >> "$BASH_ENV"
-            source "$BASH_ENV"
-            echo $TF_VER
-      - run:
-          name: fetch cuda version
-          command: |
-            export CUDA_VER=$(sudo docker run --rm $IMAGE_TAG_NAME /bin/bash -c 'nvcc -V' | grep -o 'release [0-9.]*' | awk '{print $2}')
-            echo "export CUDA_VER" >> "$BASH_ENV"
-            source "$BASH_ENV"
-            echo $CUDA_VER
-#      - run:
-#          name: docker push
-#          command: |
-#            docker push $IMAGE_TAG_NAME
-#          no_output_timeout: 1h
+            cd ./<<parameters.path>> &&  sudo docker build --platform=linux/amd64 --build-arg NGC_TAG=<<parameters.tag>> -f Dockerfile.<<parameters.filename>> -t $IMAGE_TAG_NAME .
 
 executors:
   kernel-image-publishing-docker:
@@ -87,10 +179,12 @@ jobs:
             echo "export DATE=$(date +'%Y%m%d%H%M')" >> "$BASH_ENV"
             echo "export NGC_TAG_VERSION=$(date -d '-1 months' '+%y.%m')" >> "$BASH_ENV"
             source "$BASH_ENV"
-      - push-docker-image:
+      - build-docker-image:
           filename: "py3-tf-ngc"
           tag: "$NGC_TAG_VERSION-tf2-py3"
           repo: "tensorflow"
+      - overwrite-tag-tf
+      - push-docker-image
 #      - insert-image-database
 #      - slack/status:
 #          include_project_field: false
@@ -109,17 +203,19 @@ jobs:
             echo "export DATE=$(date +'%Y%m%d%H%M')" >> "$BASH_ENV"
             echo "export NGC_TAG_VERSION=$(date -d '-1 months' '+%y.%m')" >> "$BASH_ENV"
             source "$BASH_ENV"
-      - push-docker-image:
+      - build-docker-image:
           filename: "py3-torch-ngc"
           tag: "$NGC_TAG_VERSION-py3"
-          repo: "ngc-pytorch-kernel"
-      - insert-image-database
-      - slack/status:
-          include_project_field: false
-          include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n
-          <https://docs.nvidia.com/deeplearning/frameworks/`echo $IMAGE_TAG_NAME | cut -d "/" -f 3 | cut -d "-" -f2`-release-notes/rel-`echo $NGC_TAG_VERSION | cut -d "." -f 1`-`echo $NGC_TAG_VERSION | cut -d "." -f 2`.html|*See NGC Release Notes*>'
+          repo: "torch"
+      - overwrite-tag-torch-cpu
+      - push-docker-image
+#      - insert-image-database
+#      - slack/status:
+#          include_project_field: false
+#          include_job_number_field: false
+#          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
+#          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n
+#          <https://docs.nvidia.com/deeplearning/frameworks/`echo $IMAGE_TAG_NAME | cut -d "/" -f 3 | cut -d "-" -f2`-release-notes/rel-`echo $NGC_TAG_VERSION | cut -d "." -f 1`-`echo $NGC_TAG_VERSION | cut -d "." -f 2`.html|*See NGC Release Notes*>'
   push-py38-cpu:
     executor: kernel-image-publishing-docker
     steps:
@@ -129,17 +225,19 @@ jobs:
           command: |
             echo "export DATE=$(date +'%Y%m%d%H%M')" >> "$BASH_ENV"
             source "$BASH_ENV"
-      - push-docker-image:
+      - build-docker-image:
           filename: "py38"
           tag: "py38"
           path: "cpu"
-          repo: "kernels"
-      - insert-image-database
-      - slack/status:
-          include_project_field: false
-          include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+          repo: "python"
+      - overwrite-tag-python-cpu
+      - push-docker-image
+#      - insert-image-database
+#      - slack/status:
+#          include_project_field: false
+#          include_job_number_field: false
+#          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
+#          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
   push-py39-cpu:
     executor: kernel-image-publishing-docker
     steps:
@@ -149,17 +247,19 @@ jobs:
           command: |
             echo "export DATE=$(date +'%Y%m%d%H%M')" >> "$BASH_ENV"
             source "$BASH_ENV"
-      - push-docker-image:
+      - build-docker-image:
           filename: "py39"
           tag: "py39"
           path: "cpu"
-          repo: "kernels"
-      - insert-image-database
-      - slack/status:
-          include_project_field: false
-          include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+          repo: "python"
+      - overwrite-tag-python-cpu
+      - push-docker-image
+#      - insert-image-database
+#      - slack/status:
+#          include_project_field: false
+#          include_job_number_field: false
+#          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
+#          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
   push-py310-cpu:
     executor: kernel-image-publishing-docker
     steps:
@@ -169,17 +269,19 @@ jobs:
           command: |
             echo "export DATE=$(date +'%Y%m%d%H%M')" >> "$BASH_ENV"
             source "$BASH_ENV"
-      - push-docker-image:
+      - build-docker-image:
           filename: "py310"
           tag: "py310"
           path: "cpu"
-          repo: "kernels"
-      - insert-image-database
-      - slack/status:
-          include_project_field: false
-          include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'  
+          repo: "python"
+      - overwrite-tag-python-cpu
+      - push-docker-image
+#      - insert-image-database
+#      - slack/status:
+#          include_project_field: false
+#          include_job_number_field: false
+#          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
+#          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
   push-py311-cpu:
     executor: kernel-image-publishing-docker
     steps:
@@ -189,17 +291,19 @@ jobs:
           command: |
             echo "export DATE=$(date +'%Y%m%d%H%M')" >> "$BASH_ENV"
             source "$BASH_ENV"
-      - push-docker-image:
+      - build-docker-image:
           filename: "py311"
           tag: "py311"
           path: "cpu"
-          repo: "kernels"
-      - insert-image-database
-      - slack/status:
-          include_project_field: false
-          include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+          repo: "python"
+      - overwrite-tag-python-cpu
+      - push-docker-image
+#      - insert-image-database
+#      - slack/status:
+#          include_project_field: false
+#          include_job_number_field: false
+#          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
+#          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
   push-hub:
     executor: kernel-image-publishing-docker
     steps:
@@ -209,17 +313,19 @@ jobs:
           command: |
             echo "export DATE=$(date +'%Y%m%d%H%M')" >> "$BASH_ENV"
             source "$BASH_ENV"
-      - push-docker-image:
+      - build-docker-image:
           filename: "torch2.1.0-cuda12.2"
           tag: "torch2.1.0-cuda12.2"
           path: "hub"
-          repo: "hub"
+          repo: "torch"
+      - overwrite-tag-torch-gpu
+      - push-docker-image
       # - insert-image-database
-      - slack/status:
-          include_project_field: false
-          include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+#      - slack/status:
+#          include_project_field: false
+#          include_job_number_field: false
+#          failure_message: ':thinking_spin: \``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\` image publishing job has failed \n'
+#          success_message: ':blob-cool: <https://$IMAGE_TAG_NAME|\``echo ${IMAGE_TAG_NAME} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
 
 workflows: 
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,43 +12,39 @@ commands:
             curl -v -f -X POST https://api.vessl.ai/api/v1/kernels_images/publish_new_managed_image \
               -H "Authorization: $PROD_KERNEL_IMAGE_PUBLISH_SECRET_KEY" \
               -H "Content-type: application/json" \
-              -d "{\"image_url\": \"$NEW_TAG\"}"
+              -d "{\"image_url\": \"$VERSION_REV_TAG\"}"
   fetch-py-ver:
     steps:
       - run:
           name: fetch python version
           command: |
-            PY_VER=$(sudo docker run --rm $IMAGE_TAG_NAME /bin/bash -c 'python3 -V' | grep -o 'Python [0-9.]*' | awk '{print $2}')
+            PY_VER=$(sudo docker run --rm $TEMP_TAG /bin/bash -c "python -c 'import sys; print(\".\".join(map(str, sys.version_info[:3])))'")
             echo "export PY_VER=$PY_VER" >> "$BASH_ENV"
             source "$BASH_ENV"
-            echo $PY_VER
   fetch-tf-ver:
     steps:
       - run:
           name: fetch tensorflow version
           command: |
-            TF_VER=$(sudo docker run --rm $IMAGE_TAG_NAME /bin/bash -c 'pip show tensorflow' | grep -o 'Version: [0-9.]*' | awk '{print $2}')
+            TF_VER=$(sudo docker run --rm $TEMP_TAG /bin/bash -c 'pip show tensorflow' | grep -o '^Version: [0-9.]*' | awk '{print $2}')
             echo "export TF_VER=$TF_VER" >> "$BASH_ENV"
             source "$BASH_ENV"
-            echo $TF_VER
   fetch-cuda-ver:
     steps:
       - run:
           name: fetch cuda version
           command: |
-            CUDA_VER=$(sudo docker run --rm $IMAGE_TAG_NAME /bin/bash -c 'nvcc -V' | grep -o 'release [0-9.]*' | awk '{print $2}')
+            CUDA_VER=$(sudo docker run --rm $TEMP_TAG /bin/bash -c 'nvcc -V' | grep -o 'release [0-9.]*' | awk '{print $2}')
             echo "export CUDA_VER=$CUDA_VER" >> "$BASH_ENV"
             source "$BASH_ENV"
-            echo $CUDA_VER
   fetch-torch-ver:
     steps:
       - run:
           name: fetch pytorch version
           command: |
-            TORCH_VER=$(sudo docker run --rm $IMAGE_TAG_NAME /bin/bash | grep -o 'Version [0-9.]*' | awk '{print $2}')
+            TORCH_VER=$(sudo docker run --rm $TEMP_TAG /bin/bash -c "python -c 'import torch; print(torch.__version__)'" | grep -o '^[0-9.]*')
             echo "export TORCH_VER=$TORCH_VER" >> "$BASH_ENV"
             source "$BASH_ENV"
-            echo $TORCH_VER
   overwrite-tag-tf:
     steps:
       - fetch-tf-ver
@@ -61,17 +57,6 @@ commands:
             source "$BASH_ENV"
       - fetch-revision-ver:
           repo: "tensorflow"
-  overwrite-tag-torch-cpu:
-    steps:
-      - fetch-torch-ver
-      - run:
-          name: overwrite torch-cpu version info
-          command: |
-            VERSION_TAG=$TORCH_VER-cpu
-            echo "export VERSION_TAG=$VERSION_TAG" >> "$BASH_ENV"
-            source "$BASH_ENV"
-      - fetch-revision-ver:
-          repo: "torch"
   overwrite-tag-torch-gpu:
     steps:
       - fetch-torch-ver
@@ -111,22 +96,21 @@ commands:
               fi
               suffix=$((suffix + 1))
             done
-            echo $suffix
-            NEW_TAG=$QUAY_ACCOUNT_URL/<<parameters.repo>>:$VERSION_TAG-r$suffix
-            echo "export NEW_TAG=$NEW_TAG" >> "$BASH_ENV"
+            VERSION_REV_TAG=$QUAY_ACCOUNT_URL/<<parameters.repo>>:$VERSION_TAG-r$suffix
+            echo "export VERSION_REV_TAG=$VERSION_REV_TAG" >> "$BASH_ENV"
             source "$BASH_ENV"
   push-docker-image:
     steps:
       - run:
           name: docker push
           command: |
-            echo "PUSHED $IMAGE_TAG_NAME AS $NEW_TAG"
-            WITHOUT_REV_VER=$(echo "$NEW_TAG" | sed 's/-r[0-9]*$//')
-            docker tag $IMAGE_TAG_NAME $NEW_TAG
-            docker tag $IMAGE_TAG_NAME $WITHOUT_REV_VER
-            docker push $NEW_TAG
-            docker push $WITHOUT_REV_VER
-            no_output_timeout: 1h
+            echo "PUSHED $TEMP_TAG AS $VERSION_REV_TAG"
+            LATEST_TAG=$(echo "$VERSION_REV_TAG" | sed 's/-r[0-9]*$//')
+            docker tag $TEMP_TAG $VERSION_REV_TAG
+            docker tag $TEMP_TAG $LATEST_TAG
+            docker push $VERSION_REV_TAG
+            docker push $LATEST_TAG
+          no_output_timeout: 1h
 
   build-docker-image:
     parameters:
@@ -152,12 +136,12 @@ commands:
           name: store image tag
           command: |
             export TAG="$QUAY_ACCOUNT_URL/<<parameters.repo>>:<<parameters.tag>>"
-            echo "export IMAGE_TAG_NAME=$TAG" >> "$BASH_ENV"
+            echo "export TEMP_TAG=$TAG" >> "$BASH_ENV"
             source "$BASH_ENV"
       - run:
           name: docker build
           command: |
-            cd ./<<parameters.path>> &&  docker build --platform=linux/amd64 --build-arg NGC_TAG=<<parameters.tag>> -f Dockerfile.<<parameters.filename>> -t $IMAGE_TAG_NAME .
+            cd ./<<parameters.path>> &&  docker build --build-arg NGC_TAG=<<parameters.tag>> -f Dockerfile.<<parameters.filename>> -t $TEMP_TAG .
 
 executors:
   kernel-image-publishing-docker:
@@ -186,9 +170,9 @@ jobs:
       - slack/status:
           include_project_field: false
           include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${NEW_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$NEW_TAG|\``echo ${NEW_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n
-          <https://docs.nvidia.com/deeplearning/frameworks/`echo $NEW_TAG | cut -d "/" -f 3 | cut -d "-" -f2`-release-notes/rel-`echo $NGC_TAG_VERSION | cut -d "." -f 1`-`echo $NGC_TAG_VERSION | cut -d "." -f 2`.html|*See NGC Release Notes*>'
+          failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n
+          <https://docs.nvidia.com/deeplearning/frameworks/`echo $VERSION_REV_TAG | cut -d "/" -f 3 | cut -d "-" -f2`-release-notes/rel-`echo $NGC_TAG_VERSION | cut -d "." -f 1`-`echo $NGC_TAG_VERSION | cut -d "." -f 2`.html|*See NGC Release Notes*>'
 
   push-pytorch-ngc-prev:
     executor: kernel-image-publishing-docker
@@ -204,15 +188,15 @@ jobs:
           filename: "py3-torch-ngc"
           tag: "$NGC_TAG_VERSION-py3"
           repo: "torch"
-      - overwrite-tag-torch-cpu
+      - overwrite-tag-torch-gpu
       - push-docker-image
       - insert-image-database
       - slack/status:
           include_project_field: false
           include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${NEW_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$NEW_TAG|\``echo ${NEW_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n
-          <https://docs.nvidia.com/deeplearning/frameworks/`echo $NEW_TAG | cut -d "/" -f 3 | cut -d "-" -f2`-release-notes/rel-`echo $NGC_TAG_VERSION | cut -d "." -f 1`-`echo $NGC_TAG_VERSION | cut -d "." -f 2`.html|*See NGC Release Notes*>'
+          failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n
+          <https://docs.nvidia.com/deeplearning/frameworks/`echo $VERSION_REV_TAG | cut -d "/" -f 3 | cut -d "-" -f2`-release-notes/rel-`echo $NGC_TAG_VERSION | cut -d "." -f 1`-`echo $NGC_TAG_VERSION | cut -d "." -f 2`.html|*See NGC Release Notes*>'
 
   push-py38-cpu:
     executor: kernel-image-publishing-docker
@@ -234,8 +218,8 @@ jobs:
       - slack/status:
           include_project_field: false
           include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${NEW_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$NEW_TAG|\``echo ${NEW_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+          failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
 
   push-py39-cpu:
     executor: kernel-image-publishing-docker
@@ -257,8 +241,8 @@ jobs:
       - slack/status:
           include_project_field: false
           include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${NEW_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$NEW_TAG|\``echo ${NEW_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+          failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
 
   push-py310-cpu:
     executor: kernel-image-publishing-docker
@@ -280,8 +264,8 @@ jobs:
       - slack/status:
           include_project_field: false
           include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${NEW_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$NEW_TAG|\``echo ${NEW_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+          failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
 
   push-py311-cpu:
     executor: kernel-image-publishing-docker
@@ -303,8 +287,8 @@ jobs:
       - slack/status:
           include_project_field: false
           include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${NEW_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$NEW_TAG|\``echo ${NEW_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+          failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
 
   push-hub:
     executor: kernel-image-publishing-docker
@@ -326,8 +310,8 @@ jobs:
       - slack/status:
           include_project_field: false
           include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${NEW_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$NEW_TAG|\``echo ${NEW_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+          failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
 
 workflows: 
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,41 +290,9 @@ jobs:
           failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
           success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
 
-  push-hub:
-    executor: kernel-image-publishing-docker
-    steps:
-      - checkout
-      - run:
-          name: store variables
-          command: |
-            echo "export DATE=$(date +'%Y%m%d%H%M')" >> "$BASH_ENV"
-            source "$BASH_ENV"
-      - build-docker-image:
-          filename: "torch2.1.0-cuda12.2"
-          tag: "torch2.1.0-cuda12.2"
-          path: "hub"
-          repo: "torch"
-      - overwrite-tag-torch-gpu
-      - push-docker-image
-      # - insert-image-database
-      - slack/status:
-          include_project_field: false
-          include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
-
 workflows: 
   main:
     jobs:
-      - push-hub:
-          context:
-            - quay-creds
-            - kernel-image-publish-secrets
-            - slack-webhook-for-v3-orb
-          filters:
-            branches:
-              only:
-                - main
       - push-tf2-ngc-prev:
           context:
             - quay-creds


### PR DESCRIPTION
## 변경 사항

- Vessl-Managed 이미지 (NGC 이미지 기반) 태그를 바꿨습니다
	- As-is: ngc-tensorflow-kernel: 23.05-tf2-py3-202306150329
	- To-be: tensorflow:2.9.0-cuda11.2-r2
	
- 태그의 형식은 기본적으로 다음과 같습니다:
`{framework}:{framework_version}-{cuda_version}-r{internal_revision}`

- 더 자세한 논의는  [NGC Version Tagging Policy Notion](https://www.notion.so/vesslai/NGC-Version-tagging-policy-34dfab8491a54a9c82e8c1a1ed2fca1e?pvs=4) 에서 보실 수 있습니다

## 추가 설명

- 이미지마다 자세한 태그는 다르게 생성되지만, 대략적인 프로세스는 다음과 같습니다
1. 이미지 CLI 접속을 통해 버전 정보를 알아냅니다
(버전 정보를 알아내는 더 자세한 방법은 [NGC Version Info Parsing](https://www.notion.so/vesslai/NGC-700d4712aada49a6b472f6c3b08beb03?pvs=4) 에서 보실 수 있습니다)
2. 가독성이 떨어지는 타임스탬프 대신 내부 revision number를 순차적으로 사용합니다
3. 두 가지 정보를 조합하여 최종 태그 결정

=> 여기서 1, 2 두 단계로 나눠서 진행한 이유는, 버전 정보 부분까지의 태그가 다음 revision number를 결정하는데에 필요하기 때문입니다 (quay.io 에 직접 curl 해서 200 status => 존재하는 태그이므로 다음 revision number 사용. else => 아직 없는 태그이므로 사용 가능)

- revision number가 붙지 않은 "latest" 버전 관리 (유일하게 변동성있는 태그)
1. 마지막 push 단계에서 해당 이미지를 가리키는 태그를 추가로 생성 (최종 태그에서 revision number 제거)
2. 두 가지 태그 모두 push