### PR TITLE
Trim CPU images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,6 +320,7 @@ workflows:
             branches:
               only:
                 - main
+                - amelia/trim-cpu
       - push-py310-cpu:
           context:
             - quay-creds
@@ -329,6 +330,7 @@ workflows:
             branches:
               only:
                 - main
+                - amelia/trim-cpu
       - push-py39-cpu:
           context:
             - quay-creds
@@ -338,6 +340,7 @@ workflows:
             branches:
               only:
                 - main
+                - amelia/trim-cpu
       - push-py38-cpu:
           context:
             - quay-creds
@@ -347,3 +350,4 @@ workflows:
             branches:
               only:
                 - main
+                - amelia/trim-cpu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,13 +213,13 @@ jobs:
           path: "cpu"
           repo: "python"
       - overwrite-tag-python-cpu
-      # - push-docker-image
-      # - insert-image-database
-      # - slack/status:
-      #     include_project_field: false
-      #     include_job_number_field: false
-      #     failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
-      #     success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+      - push-docker-image
+      - insert-image-database
+      - slack/status:
+          include_project_field: false
+          include_job_number_field: false
+          failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
 
   push-py39-cpu:
     executor: kernel-image-publishing-docker
@@ -236,13 +236,13 @@ jobs:
           path: "cpu"
           repo: "python"
       - overwrite-tag-python-cpu
-      # - push-docker-image
-      # - insert-image-database
-      # - slack/status:
-      #     include_project_field: false
-      #     include_job_number_field: false
-      #     failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
-      #     success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+      - push-docker-image
+      - insert-image-database
+      - slack/status:
+          include_project_field: false
+          include_job_number_field: false
+          failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
 
   push-py310-cpu:
     executor: kernel-image-publishing-docker
@@ -259,13 +259,13 @@ jobs:
           path: "cpu"
           repo: "python"
       - overwrite-tag-python-cpu
-      # - push-docker-image
-      # - insert-image-database
-      # - slack/status:
-      #     include_project_field: false
-      #     include_job_number_field: false
-      #     failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
-      #     success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+      - push-docker-image
+      - insert-image-database
+      - slack/status:
+          include_project_field: false
+          include_job_number_field: false
+          failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
 
   push-py311-cpu:
     executor: kernel-image-publishing-docker
@@ -282,35 +282,35 @@ jobs:
           path: "cpu"
           repo: "python"
       - overwrite-tag-python-cpu
-      # - push-docker-image
-      # - insert-image-database
-      # - slack/status:
-      #     include_project_field: false
-      #     include_job_number_field: false
-      #     failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
-      #     success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+      - push-docker-image
+      - insert-image-database
+      - slack/status:
+          include_project_field: false
+          include_job_number_field: false
+          failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+          success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
 
 workflows: 
   main:
     jobs:
-      # - push-tf2-ngc-prev:
-      #     context:
-      #       - quay-creds
-      #       - kernel-image-publish-secrets
-      #       - slack-webhook-for-v3-orb
-      #     filters:
-      #       branches:
-      #         only:
-      #           - main
-      # - push-pytorch-ngc-prev:
-      #     context:
-      #       - quay-creds
-      #       - kernel-image-publish-secrets
-      #       - slack-webhook-for-v3-orb
-      #     filters:
-      #       branches:
-      #         only:
-      #           - main
+      - push-tf2-ngc-prev:
+          context:
+            - quay-creds
+            - kernel-image-publish-secrets
+            - slack-webhook-for-v3-orb
+          filters:
+            branches:
+              only:
+                - main
+      - push-pytorch-ngc-prev:
+          context:
+            - quay-creds
+            - kernel-image-publish-secrets
+            - slack-webhook-for-v3-orb
+          filters:
+            branches:
+              only:
+                - main
       - push-py311-cpu:
           context:
             - quay-creds
@@ -320,7 +320,6 @@ workflows:
             branches:
               only:
                 - main
-                - amelia/trim-cpu
       - push-py310-cpu:
           context:
             - quay-creds
@@ -330,7 +329,6 @@ workflows:
             branches:
               only:
                 - main
-                - amelia/trim-cpu
       - push-py39-cpu:
           context:
             - quay-creds
@@ -340,7 +338,6 @@ workflows:
             branches:
               only:
                 - main
-                - amelia/trim-cpu
       - push-py38-cpu:
           context:
             - quay-creds
@@ -350,4 +347,3 @@ workflows:
             branches:
               only:
                 - main
-                - amelia/trim-cpu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ commands:
         type: string
     steps:
       - setup_remote_docker:
-            version: 20.10.17
+            version: default
             docker_layer_caching: true
       - run:
           name: docker login

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,13 +213,13 @@ jobs:
           path: "cpu"
           repo: "python"
       - overwrite-tag-python-cpu
-      - push-docker-image
-      - insert-image-database
-      - slack/status:
-          include_project_field: false
-          include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+      # - push-docker-image
+      # - insert-image-database
+      # - slack/status:
+      #     include_project_field: false
+      #     include_job_number_field: false
+      #     failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+      #     success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
 
   push-py39-cpu:
     executor: kernel-image-publishing-docker
@@ -236,13 +236,13 @@ jobs:
           path: "cpu"
           repo: "python"
       - overwrite-tag-python-cpu
-      - push-docker-image
-      - insert-image-database
-      - slack/status:
-          include_project_field: false
-          include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+      # - push-docker-image
+      # - insert-image-database
+      # - slack/status:
+      #     include_project_field: false
+      #     include_job_number_field: false
+      #     failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+      #     success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
 
   push-py310-cpu:
     executor: kernel-image-publishing-docker
@@ -259,13 +259,13 @@ jobs:
           path: "cpu"
           repo: "python"
       - overwrite-tag-python-cpu
-      - push-docker-image
-      - insert-image-database
-      - slack/status:
-          include_project_field: false
-          include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+      # - push-docker-image
+      # - insert-image-database
+      # - slack/status:
+      #     include_project_field: false
+      #     include_job_number_field: false
+      #     failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+      #     success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
 
   push-py311-cpu:
     executor: kernel-image-publishing-docker
@@ -282,35 +282,35 @@ jobs:
           path: "cpu"
           repo: "python"
       - overwrite-tag-python-cpu
-      - push-docker-image
-      - insert-image-database
-      - slack/status:
-          include_project_field: false
-          include_job_number_field: false
-          failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
-          success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
+      # - push-docker-image
+      # - insert-image-database
+      # - slack/status:
+      #     include_project_field: false
+      #     include_job_number_field: false
+      #     failure_message: ':thinking_spin: \``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\` image publishing job has failed \n'
+      #     success_message: ':blob-cool: <https://$VERSION_REV_TAG|\``echo ${VERSION_REV_TAG} | cut -d "/" -f 3`\`>  image publishing job has succeeded! \n'
 
 workflows: 
   main:
     jobs:
-      - push-tf2-ngc-prev:
-          context:
-            - quay-creds
-            - kernel-image-publish-secrets
-            - slack-webhook-for-v3-orb
-          filters:
-            branches:
-              only:
-                - main
-      - push-pytorch-ngc-prev:
-          context:
-            - quay-creds
-            - kernel-image-publish-secrets
-            - slack-webhook-for-v3-orb
-          filters:
-            branches:
-              only:
-                - main
+      # - push-tf2-ngc-prev:
+      #     context:
+      #       - quay-creds
+      #       - kernel-image-publish-secrets
+      #       - slack-webhook-for-v3-orb
+      #     filters:
+      #       branches:
+      #         only:
+      #           - main
+      # - push-pytorch-ngc-prev:
+      #     context:
+      #       - quay-creds
+      #       - kernel-image-publish-secrets
+      #       - slack-webhook-for-v3-orb
+      #     filters:
+      #       branches:
+      #         only:
+      #           - main
       - push-py311-cpu:
           context:
             - quay-creds

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ VESSL images for experiment and workspace
 All **VESSL Images** have the most used data science python package installed. The full list of **DS** packages are as follows.
 
 ```bash
-numpy, scipy, pandas, matplotlib, scikit-learn, opencv-python, seaborn, plotly, tqdm
+numpy, scipy, pandas, matplotlib, scikit-learn, opencv-python, seaborn, tqdm
 ```
 
 ### Image tag

--- a/cpu/Dockerfile.py310
+++ b/cpu/Dockerfile.py310
@@ -28,7 +28,9 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir --no-compile -U pip
+RUN pip install --no-cache-dir --no-compile -U pip && \
+    rm -rf /root/.cache && \
+    rm -f /tmp/*.whl
 
 # Install pypi data science related dependencies
 COPY requirements.datascience.txt requirements.txt
@@ -38,7 +40,9 @@ RUN pip install --no-cache-dir --no-compile -r requirements.txt && \
     rm -f requirements.txt
 
 # Install CLI
-RUN pip install --no-cache-dir --no-compile vessl
+RUN pip install --no-cache-dir --no-compile vessl && \
+    rm -rf /root/.cache && \
+    rm -f /tmp/*.whl
 
 RUN pip install --no-cache-dir --no-compile \
     mxnet==$MXNET_VERSION \
@@ -55,13 +59,15 @@ RUN pip install --no-cache-dir --no-compile \
 RUN pip install --no-cache-dir --no-compile \
     jupyterlab jupyterlab-git ipywidgets && \
     rm -rf /root/.cache && \
-    rm -f /tmp/*.whl && \
-    rm -f requirements.txt
+    rm -f /tmp/*.whl
 
 # Install git-lfs
-RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
-    && apt-get install git-lfs \
-    && git lfs install
+RUN apt-get update && \
+    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    apt-get install git-lfs && \
+    git lfs install && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY start-notebook.sh /usr/local/bin/
 CMD ["start-notebook.sh"]

--- a/cpu/Dockerfile.py310
+++ b/cpu/Dockerfile.py310
@@ -11,8 +11,6 @@ ENV TF_HUB 0.13.0
 ENV TORCH_VERSION 1.13.1
 ENV TORCHVISION_VERSION 0.14.1
 
-ENV JUPYTER_ENABLE_LAB=TRUE
-
 USER root
 
 RUN apt-get update && \
@@ -23,7 +21,6 @@ RUN apt-get update && \
         libgeos-dev libgeos++-dev libglib2.0-0 libgl1-mesa-glx libmpdec2 libproj-dev libsndfile1 libssl-dev \
         mime-support \
         openssh-server \
-        proj-bin \
         sudo \
         vim jq tmux \
         unzip zip \
@@ -31,60 +28,35 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+RUN pip install --no-cache-dir --no-compile -U pip
+
 # Install pypi data science related dependencies
 COPY requirements.datascience.txt requirements.txt
-RUN pip install -U pip && \
-    pip install --no-cache-dir -r requirements.txt && \
+RUN pip install --no-cache-dir --no-compile -r requirements.txt && \
     rm -rf /root/.cache && \
     rm -f /tmp/*.whl && \
     rm -f requirements.txt
 
-
-RUN pip install --upgrade pip
-
 # Install CLI
-RUN pip install --no-cache-dir vessl
+RUN pip install --no-cache-dir --no-compile vessl
 
-RUN pip install --no-cache-dir \
+RUN pip install --no-cache-dir --no-compile \
     mxnet==$MXNET_VERSION \
     tensorflow-cpu==$TF_VERSION \
     tensorboard \
     torch==${TORCH_VERSION}+cpu \
     torchvision==${TORCHVISION_VERSION}+cpu \
-    keras keras_applications keras_preprocessing \
+    keras \
     tensorflow-hub==$TF_HUB tf2onnx \
     --extra-index-url https://download.pytorch.org/whl/cpu && \
     rm -rf /root/.cache && \
     rm -f /tmp/*.whl
 
-# Install nodejs
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install Jupyter prerequisite packages
-COPY requirements.prereq.jupyter.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt && \
+RUN pip install --no-cache-dir --no-compile \
+    jupyterlab jupyterlab-git ipywidgets && \
     rm -rf /root/.cache && \
     rm -f /tmp/*.whl && \
     rm -f requirements.txt
-
-# Install Jupyter requirements
-COPY requirements.jupyter.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt && \
-    rm -rf /root/.cache && \
-    rm -f /tmp/*.whl && \
-    rm -f requirements.txt
-
-# Jupyterlab extension install
-RUN jupyter serverextension enable --py jupyterlab --sys-prefix
-
-RUN jupyter labextension install --no-build @jupyterlab/git && \
-    jupyter lab build --dev-build=False --minimize=False
-
-# Install ipython kernelspec
-RUN python -m ipykernel install --display-name "Full on Python 3.10 (CPU-only)" && \
-    cat /usr/local/share/jupyter/kernels/python3/kernel.json
 
 # Install git-lfs
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \

--- a/cpu/Dockerfile.py311
+++ b/cpu/Dockerfile.py311
@@ -11,8 +11,6 @@ ENV TF_HUB 0.13.0
 ENV TORCH_VERSION 2.0.1
 ENV TORCHVISION_VERSION 0.15.2
 
-ENV JUPYTER_ENABLE_LAB=TRUE
-
 USER root
 
 RUN apt-get update && \
@@ -23,7 +21,6 @@ RUN apt-get update && \
         libgeos-dev libgeos++-dev libglib2.0-0 libgl1-mesa-glx libmpdec2 libproj-dev libsndfile1 libssl-dev \
         mime-support \
         openssh-server \
-        proj-bin \
         sudo \
         vim jq tmux \
         unzip zip \
@@ -31,60 +28,38 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+RUN pip install --no-cache-dir --no-compile -U pip && \
+    rm -rf /root/.cache && \
+    rm -f /tmp/*.whl
+
 # Install pypi data science related dependencies
 COPY requirements.datascience.txt requirements.txt
-RUN pip install -U pip && \
-    pip install --no-cache-dir -r requirements.txt && \
+RUN pip install --no-cache-dir --no-compile -r requirements.txt && \
     rm -rf /root/.cache && \
     rm -f /tmp/*.whl && \
     rm -f requirements.txt
 
-
-RUN pip install --upgrade pip
-
 # Install CLI
-RUN pip install --no-cache-dir vessl
+RUN pip install --no-cache-dir --no-compile vessl && \
+    rm -rf /root/.cache && \
+    rm -f /tmp/*.whl
 
-RUN pip install --no-cache-dir \
+RUN pip install --no-cache-dir --no-compile \
     mxnet==$MXNET_VERSION \
     tensorflow-cpu==$TF_VERSION \
     tensorboard \
     torch==${TORCH_VERSION}+cpu \
     torchvision==${TORCHVISION_VERSION}+cpu \
-    keras keras_applications keras_preprocessing \
+    keras \
     tensorflow-hub==$TF_HUB tf2onnx \
     --extra-index-url https://download.pytorch.org/whl/cpu && \
     rm -rf /root/.cache && \
     rm -f /tmp/*.whl
 
-# Install nodejs
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install Jupyter prerequisite packages
-COPY requirements.prereq.jupyter.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt && \
+RUN pip install --no-cache-dir --no-compile \
+    jupyterlab jupyterlab-git ipywidgets && \
     rm -rf /root/.cache && \
-    rm -f /tmp/*.whl && \
-    rm -f requirements.txt
-
-# Install Jupyter requirements
-COPY requirements.jupyter.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt && \
-    rm -rf /root/.cache && \
-    rm -f /tmp/*.whl && \
-    rm -f requirements.txt
-
-# Jupyterlab extension install
-RUN jupyter serverextension enable --py jupyterlab --sys-prefix
-
-RUN jupyter labextension install --no-build @jupyterlab/git && \
-    jupyter lab build --dev-build=False --minimize=False
-
-# Install ipython kernelspec
-RUN python -m ipykernel install --display-name "Full on Python 3.11 (CPU-only)" && \
-    cat /usr/local/share/jupyter/kernels/python3/kernel.json
+    rm -f /tmp/*.whl
 
 # Install git-lfs
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \

--- a/cpu/Dockerfile.py311
+++ b/cpu/Dockerfile.py311
@@ -62,9 +62,12 @@ RUN pip install --no-cache-dir --no-compile \
     rm -f /tmp/*.whl
 
 # Install git-lfs
-RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
-    && apt-get install git-lfs \
-    && git lfs install
+RUN apt-get update && \
+    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    apt-get install git-lfs && \
+    git lfs install && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY start-notebook.sh /usr/local/bin/
 CMD ["start-notebook.sh"]

--- a/cpu/Dockerfile.py38
+++ b/cpu/Dockerfile.py38
@@ -28,7 +28,9 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir --no-compile -U pip
+RUN pip install --no-cache-dir --no-compile -U pip && \
+    rm -rf /root/.cache && \
+    rm -f /tmp/*.whl
 
 # Install pypi data science related dependencies
 COPY requirements.datascience.txt requirements.txt
@@ -38,7 +40,9 @@ RUN pip install --no-cache-dir --no-compile -r requirements.txt && \
     rm -f requirements.txt
 
 # Install CLI
-RUN pip install --no-cache-dir --no-compile vessl
+RUN pip install --no-cache-dir --no-compile vessl && \
+    rm -rf /root/.cache && \
+    rm -f /tmp/*.whl
 
 RUN pip install --no-cache-dir --no-compile \
     mxnet==$MXNET_VERSION \
@@ -55,13 +59,15 @@ RUN pip install --no-cache-dir --no-compile \
 RUN pip install --no-cache-dir --no-compile \
     jupyterlab jupyterlab-git ipywidgets && \
     rm -rf /root/.cache && \
-    rm -f /tmp/*.whl && \
-    rm -f requirements.txt
+    rm -f /tmp/*.whl
 
 # Install git-lfs
-RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
-    && apt-get install git-lfs \
-    && git lfs install
+RUN apt-get update && \
+    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    apt-get install git-lfs && \
+    git lfs install && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY start-notebook.sh /usr/local/bin/
 CMD ["start-notebook.sh"]

--- a/cpu/Dockerfile.py38
+++ b/cpu/Dockerfile.py38
@@ -11,8 +11,6 @@ ENV TF_HUB 0.13.0
 ENV TORCH_VERSION 1.13.1
 ENV TORCHVISION_VERSION 0.14.1
 
-ENV JUPYTER_ENABLE_LAB=TRUE
-
 USER root
 
 RUN apt-get update && \
@@ -23,7 +21,6 @@ RUN apt-get update && \
         libgeos-dev libgeos++-dev libglib2.0-0 libgl1-mesa-glx libmpdec2 libproj-dev libsndfile1 libssl-dev \
         mime-support \
         openssh-server \
-        proj-bin \
         sudo \
         vim jq tmux \
         unzip zip \
@@ -31,60 +28,35 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+RUN pip install --no-cache-dir --no-compile -U pip
+
 # Install pypi data science related dependencies
 COPY requirements.datascience.txt requirements.txt
-RUN pip install -U pip && \
-	pip install --no-cache-dir -r requirements.txt && \
+RUN pip install --no-cache-dir --no-compile -r requirements.txt && \
     rm -rf /root/.cache && \
     rm -f /tmp/*.whl && \
     rm -f requirements.txt
 
-
-RUN pip install --upgrade pip
-
 # Install CLI
-RUN pip install --no-cache-dir vessl
+RUN pip install --no-cache-dir --no-compile vessl
 
-RUN pip install --no-cache-dir \
+RUN pip install --no-cache-dir --no-compile \
     mxnet==$MXNET_VERSION \
     tensorflow-cpu==$TF_VERSION \
     tensorboard \
     torch==${TORCH_VERSION}+cpu \
     torchvision==${TORCHVISION_VERSION}+cpu \
-    keras keras_applications keras_preprocessing \
+    keras \
     tensorflow-hub==$TF_HUB tf2onnx \
     --extra-index-url https://download.pytorch.org/whl/cpu && \
     rm -rf /root/.cache && \
     rm -f /tmp/*.whl
 
-# Install nodejs
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install Jupyter prerequisite packages
-COPY requirements.prereq.jupyter.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt && \
+RUN pip install --no-cache-dir --no-compile \
+    jupyterlab jupyterlab-git ipywidgets && \
     rm -rf /root/.cache && \
     rm -f /tmp/*.whl && \
     rm -f requirements.txt
-
-# Install Jupyter requirements
-COPY requirements.jupyter.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt && \
-    rm -rf /root/.cache && \
-    rm -f /tmp/*.whl && \
-    rm -f requirements.txt
-
-# Jupyterlab extension install
-RUN jupyter serverextension enable --py jupyterlab --sys-prefix
-
-RUN jupyter labextension install --no-build @jupyterlab/git && \
-    jupyter lab build --dev-build=False --minimize=False
-
-# Install ipython kernelspec
-RUN python -m ipykernel install --display-name "Full on Python 3.8 (CPU-only)" && \
-    cat /usr/local/share/jupyter/kernels/python3/kernel.json
 
 # Install git-lfs
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \

--- a/cpu/Dockerfile.py39
+++ b/cpu/Dockerfile.py39
@@ -28,7 +28,9 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir --no-compile -U pip
+RUN pip install --no-cache-dir --no-compile -U pip && \
+    rm -rf /root/.cache && \
+    rm -f /tmp/*.whl
 
 # Install pypi data science related dependencies
 COPY requirements.datascience.txt requirements.txt
@@ -38,7 +40,9 @@ RUN pip install --no-cache-dir --no-compile -r requirements.txt && \
     rm -f requirements.txt
 
 # Install CLI
-RUN pip install --no-cache-dir --no-compile vessl
+RUN pip install --no-cache-dir --no-compile vessl && \
+    rm -rf /root/.cache && \
+    rm -f /tmp/*.whl
 
 RUN pip install --no-cache-dir --no-compile \
     mxnet==$MXNET_VERSION \
@@ -55,13 +59,15 @@ RUN pip install --no-cache-dir --no-compile \
 RUN pip install --no-cache-dir --no-compile \
     jupyterlab jupyterlab-git ipywidgets && \
     rm -rf /root/.cache && \
-    rm -f /tmp/*.whl && \
-    rm -f requirements.txt
+    rm -f /tmp/*.whl
 
 # Install git-lfs
-RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
-    && apt-get install git-lfs \
-    && git lfs install
+RUN apt-get update && \
+    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    apt-get install git-lfs && \
+    git lfs install && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY start-notebook.sh /usr/local/bin/
 CMD ["start-notebook.sh"]

--- a/cpu/Dockerfile.py39
+++ b/cpu/Dockerfile.py39
@@ -11,8 +11,6 @@ ENV TF_HUB 0.13.0
 ENV TORCH_VERSION 1.13.1
 ENV TORCHVISION_VERSION 0.14.1
 
-ENV JUPYTER_ENABLE_LAB=TRUE
-
 USER root
 
 RUN apt-get update && \
@@ -23,7 +21,6 @@ RUN apt-get update && \
         libgeos-dev libgeos++-dev libglib2.0-0 libgl1-mesa-glx libmpdec2 libproj-dev libsndfile1 libssl-dev \
         mime-support \
         openssh-server \
-        proj-bin \
         sudo \
         vim jq tmux \
         unzip zip \
@@ -31,60 +28,35 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+RUN pip install --no-cache-dir --no-compile -U pip
+
 # Install pypi data science related dependencies
 COPY requirements.datascience.txt requirements.txt
-RUN pip install -U pip && \
-	pip install --no-cache-dir -r requirements.txt && \
+RUN pip install --no-cache-dir --no-compile -r requirements.txt && \
     rm -rf /root/.cache && \
     rm -f /tmp/*.whl && \
     rm -f requirements.txt
 
-
-RUN pip install --upgrade pip
-
 # Install CLI
-RUN pip install --no-cache-dir vessl
+RUN pip install --no-cache-dir --no-compile vessl
 
-RUN pip install --no-cache-dir \
+RUN pip install --no-cache-dir --no-compile \
     mxnet==$MXNET_VERSION \
     tensorflow-cpu==$TF_VERSION \
     tensorboard \
     torch==${TORCH_VERSION}+cpu \
     torchvision==${TORCHVISION_VERSION}+cpu \
-    keras keras_applications keras_preprocessing \
+    keras \
     tensorflow-hub==$TF_HUB tf2onnx \
     --extra-index-url https://download.pytorch.org/whl/cpu && \
     rm -rf /root/.cache && \
     rm -f /tmp/*.whl
 
-# Install nodejs
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install Jupyter prerequisite packages
-COPY requirements.prereq.jupyter.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt && \
+RUN pip install --no-cache-dir --no-compile \
+    jupyterlab jupyterlab-git ipywidgets && \
     rm -rf /root/.cache && \
     rm -f /tmp/*.whl && \
     rm -f requirements.txt
-
-# Install Jupyter requirements
-COPY requirements.jupyter.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt && \
-    rm -rf /root/.cache && \
-    rm -f /tmp/*.whl && \
-    rm -f requirements.txt
-
-# Jupyterlab extension install
-RUN jupyter serverextension enable --py jupyterlab --sys-prefix
-
-RUN jupyter labextension install --no-build @jupyterlab/git && \
-    jupyter lab build --dev-build=False --minimize=False
-
-# Install ipython kernelspec
-RUN python -m ipykernel install --display-name "Full on Python 3.9 (CPU-only)" && \
-    cat /usr/local/share/jupyter/kernels/python3/kernel.json
 
 # Install git-lfs
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \

--- a/cpu/requirements.datascience.txt
+++ b/cpu/requirements.datascience.txt
@@ -5,5 +5,4 @@ matplotlib
 scikit-learn
 opencv-python
 seaborn
-plotly
 tqdm

--- a/cpu/requirements.jupyter.txt
+++ b/cpu/requirements.jupyter.txt
@@ -1,4 +1,0 @@
-jupyter
-jupyterlab==3.3.4
-jupyterlab-git==0.36.0
-jupyter-tensorboard==0.2.0

--- a/cpu/requirements.prereq.jupyter.txt
+++ b/cpu/requirements.prereq.jupyter.txt
@@ -1,2 +1,0 @@
-tornado
-notebook==6.5.5

--- a/cpu/start-notebook.sh
+++ b/cpu/start-notebook.sh
@@ -4,8 +4,9 @@
 
 set -e
 
-if [[ -n "${JUPYTER_ENABLE_LAB}" ]]; then
-  jupyter lab --NotebookApp.ip=0.0.0.0 --NotebookApp.token=${VESSL_TOKEN} --NotebookApp.base_url=${VESSL_BASE_URL} --NotebookApp.allow_origin=* --no-browser "$@" --allow-root
-else
-  jupyter notebook --NotebookApp.ip=0.0.0.0 --NotebookApp.token=${VESSL_TOKEN} --NotebookApp.base_url=${VESSL_BASE_URL} --NotebookApp.allow_origin=* --no-browser "$@" --allow-root
-fi
+jupyter lab \
+  --ServerApp.ip=0.0.0.0 \
+  --ServerApp.token=${VESSL_TOKEN} \
+  --ServerApp.base_url=${VESSL_BASE_URL} \
+  --ServerApp.allow_origin="*" \
+  --no-browser "$@" --allow-root


### PR DESCRIPTION
* Entrypoint
  * Dockerfile에서 `JUPYTER_ENABLE_LAB` 플래그를 없애고, 그 플래그에 의존하는 `cpu/start-notebook.sh`의 분기를 없앱니다.
  * `cpu/start-notebook.sh`의 `NotebookApp` 설정값들이 `ServerApp`으로 이전되어서, 그것들을 옮깁니다.
* Pip
  * 모든 `pip install`에 대해 `--no-compile`을 붙입니다. (이러면 `.pyc`가 안 생기는 것 같습니다.)
  * 중복된 `pip install -U pip`를 제거하고, `--no-cache-dir`이나 `&& rm -rf /root/.cache && rm -f /tmp/*.whl`이 빠진 곳을 채웁니다.
  * deprecate된 `keras_applications`, `keras_preprocessing` 패키지를 제거합니다.
  * generated code로 인해 파일이 굉장히 많던(26,847 files, 2,839 directories) `plotly` dependency를 제거합니다.
* Jupyter
  * Node.js를 설치하고 `jupyter lab build`를 돌리던 기존의 방식을 버리고, `jupyterlab`, `jupyterlab-git`, `ipywidgets` 이렇게 세 개의 패키지만 설치합니다.
  * 이에 따라 더 이상 필요치 않게 된 `cpu/requirements.jupyter.txt`와, 언제부턴가 필요치 않았던 `cpu/requirements.prereq.jupyter.txt`를 제거합니다.